### PR TITLE
Prevent logged in users from accessing /login

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,9 @@
 class SessionsController < ApplicationController
   def new
+    if logged_in?
+        flash[:success] = "Already logged in"
+        return redirect_to root_url
+    end
   end
 
   def create


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [x] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
Adds logic to the Session controller.  
When users try to access /login, the controller will check whether they're logged into the app. 
If they are not, they will be directed to login form. If they are logged in, a message will flash and they will be redirected to the main page. 

Note: The flashed message wasn't in the issue planning but I found a silent redirect to be disorienting. I've added that message to confirm that the URL request was received and redirected. Please let me know if the message text could be improved.  

## Related PRs and/or Issues (if any)
- Closes issue #17 
-


## QA Instructions, Screenshots, Recordings
Pull into your local env and run `rails s`. 
When you're logged out, /login can be accessed in navbar. When you're logged in, /login must be accessed with url

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [ ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [ x] No documentation needed
