### PR TITLE
UI for General&Shared views step 4: change form error messages

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,14 @@ module Shiftwork2
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
+      class_attr_index = html_tag.index 'class="'
+      if class_attr_index
+        html_tag.insert class_attr_index+7, 'error '
+      else
+        html_tag.insert html_tag.index('>'), ' class="error"'
+      end
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [x] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
Currently when the form validation occurs a div.field_with_errors is added to wrap the label and the input with the error. This div gets in the middle of the bootstrap .row and label/input classes so the grid breaks.

This PR replaces that div. with an inline .error class in the label field and the input field. 


## Related PRs and/or Issues (if any)
- This problem was found on https://github.com/OurTimeForTech/shiftwork2/pull/22 
- It checks step 4 from https://github.com/OurTimeForTech/shiftwork2/issues/10


## QA Instructions, Screenshots, Recordings



## Added tests?

- [ ] yes
- [x] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [ ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
