### PR TITLE
Add authorization to Organization Show UI

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,7 +1,7 @@
 class OrganizationsController < ApplicationController
   before_action :logged_in_user, only: %i[show new create edit update]
   before_action :set_organization, only: %i[show edit update]
-  before_action :is_owner, only: %i[show new create edit update]
+  before_action :is_owner, only: %i[show edit update]
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
   
   def index
@@ -27,6 +27,10 @@ class OrganizationsController < ApplicationController
   end
 
   def edit
+    unless is_owner
+        flash[:danger] = "User cannot edit this organization."
+        redirect_to @organization
+    end
   end
 
   def update

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,6 +1,7 @@
 class OrganizationsController < ApplicationController
   before_action :logged_in_user, only: %i[show new create edit update]
   before_action :set_organization, only: %i[show edit update]
+  before_action :is_owner, only: %i[show new create edit update]
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
   
   def index
@@ -47,5 +48,11 @@ class OrganizationsController < ApplicationController
 
   def organization_params
     params.require(:organization).permit(:org_name, :org_description, :org_address, :org_city, :org_state, :user_id)
+  end
+
+  def is_owner
+    if @organization.user_id == session[:user_id]
+        @is_owner = true
+    end
   end
 end

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,9 +1,7 @@
 <div class="container">
   <h3>Your Shifts</h3>
 
-   <% if @is_owner %> 
-    <p><%= link_to "Create Shift", new_shift_path %></p>
-   <% end %>
+   <% if @is_owner %><p><%= link_to "Create Shift", new_shift_path %></p><% end %>
 
   <table>
     <thead>
@@ -28,10 +26,10 @@
           <td><%= shift.shift_end.httpdate %></td>
           <td><%= shift.shift_pay %></td>
           <td>
-           <% if @is_owner %>
+          <% if @is_owner %>
             <%= link_to "Edit", edit_shift_path(shift.id) %>
             <%= link_to "Delete", shift_path(shift.id), method: :delete, data: { confirm: "Are you sure?" } %>
-            <% end %>
+          <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,7 +1,9 @@
-<div>
+<div class="container">
   <h3>Your Shifts</h3>
 
-  <p><%= link_to 'Create Shift', new_shift_path %></p>
+   <% if @is_owner %> 
+    <p><%= link_to "Create Shift", new_shift_path %></p>
+   <% end %>
 
   <table>
     <thead>
@@ -26,8 +28,10 @@
           <td><%= shift.shift_end.httpdate %></td>
           <td><%= shift.shift_pay %></td>
           <td>
-            <%= link_to 'Edit', edit_shift_path(shift.id) %>
-            <%= link_to 'Delete', shift_path(shift.id), method: :delete, data: { confirm: 'Are you sure?' } %>
+           <% if @is_owner %>
+            <%= link_to "Edit", edit_shift_path(shift.id) %>
+            <%= link_to "Delete", shift_path(shift.id), method: :delete, data: { confirm: "Are you sure?" } %>
+            <% end %>
           </td>
         </tr>
       <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [x] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does

Shows different view elements and allow access based on whether the user owns the org
- Only users who own the org can see links to 'create a shift', 'edit', and 'delete'.
- Only users who own the org can access the org edit page. 


This is achieved by adding a method `is_owner` to run whenever the controller calls on show edit and update actions. `is_owner` creates an object that can be accessed by the `edit` method in the controller and throughout the app/views/organizations/show.html.erb file.


## Related PRs and/or Issues (if any)
- This is part of steps 3 and 4 in #12 


## QA Instructions, Screenshots, Recordings
- Start the server and navigate to http://127.0.0.1:3000
- View an org while signed in as the organization's owner
- View an same org while signed in as a user who does not own that org


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [ x ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [ ] No documentation needed
