### PR TITLE
Organisations can only see their shifts and can see the edit/create/delete shift buttons

### DIFF
--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -4,7 +4,11 @@ class ShiftsController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   def index
-    @shifts = Shift.all.order("updated_at DESC")
+    if current_user.has_org?
+      @shifts = Shift.where(organization_id: current_org_id).order("updated_at DESC") 
+    else
+      @shifts = Shift.all.order("updated_at DESC")
+    end
   end
 
   def show

--- a/app/views/shifts/index.html.erb
+++ b/app/views/shifts/index.html.erb
@@ -1,5 +1,7 @@
 <h3>List of All Shifts</h3>
-
+<% if current_user.has_org? %>
+  <p><%= link_to 'Create Shift', new_shift_path %></p>
+<% end %>
 <table>
   <thead>
     <tr>
@@ -29,6 +31,12 @@
         <% if current_user.worker? && shift.shift_open %>
           <th>
           <%= link_to 'Take Shift', take_shift_path(shift), method: :put, data: { confirm: 'You will be assigned to work this shift. Proceed?' } %>
+          </th>
+        <% end %>
+        <% if current_user.has_org? %>
+          <th>
+            <%= link_to 'Edit', edit_shift_path(shift.id) %>
+            <%= link_to 'Delete', shift_path(shift.id), method: :delete, data: { confirm: 'Are you sure?' } %>
           </th>
         <% end %>
       </tr>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [] Refactor
- [] Bug Fix
- [] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does

It allows workers to see all the list of shifts available and organisations to only see the ones they own on the index shifts page.
It also adds in the same index page a link to create a new shift and to edit or delete the ones they created if they logged user is an organisation.
It solves https://github.com/OurTimeForTech/shiftwork2/issues/13 step 4


## Related PRs and/or Issues (if any)
-
-


## QA Instructions, Screenshots, Recordings
You have to manually navigate to http://localhost:3000/shifts if logged as an organisation, as this view is pretty much the same that the one at http://localhost:3000/organizations/id. Probably will need a refactoring later on so we only use one of them.
As a worker, going to http://localhost:3000/shifts should show the full list of shifts.


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [x] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
