### PR TITLE
Sara add drop shift button to shifts view

### DIFF
--- a/app/views/shifts/index.html.erb
+++ b/app/views/shifts/index.html.erb
@@ -47,7 +47,7 @@
       <% end %>
       <% if !shift.shift_open && shift.worker_id == current_user.id %>
         <div class="text-right">
-          <%= link_to 'Drop Shift', drop_shift_path(shift), method: :put, data: { confirm: 'You are about to DROP this shift. Proceed?' }, class: "btn btn-primary" %>
+          <%= link_to 'Drop Shift', drop_shift_path(shift), method: :put, data: { confirm: 'You are about to DROP this shift. Proceed?' }, class: "btn btn-danger" %>
         </div>
       <% end %>
       </div>

--- a/app/views/shifts/index.html.erb
+++ b/app/views/shifts/index.html.erb
@@ -45,6 +45,11 @@
           <%= link_to 'Take Shift', take_shift_path(shift), method: :put, data: { confirm: 'You will be assigned to work this shift. Proceed?' }, class: "btn btn-primary" %>
         </div>
       <% end %>
+      <% if !shift.shift_open && shift.worker_id == current_user.id %>
+        <div class="text-right">
+          <%= link_to 'Drop Shift', drop_shift_path(shift), method: :put, data: { confirm: 'You are about to DROP this shift. Proceed?' }, class: "btn btn-primary" %>
+        </div>
+      <% end %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [x] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
Adds a drop shift button to the appropriate shift on the list of shifts ONLY when the user logged in is the worker who has taken the shift previously
**IT ONLY ADDS THE DROP SHIFT BUTTON. WE STILL NEED TO ADD TIME LIMIT TO WHEN WORKERS CAN DROP IT** 


## Related PRs and/or Issues (if any)
- Step 2 from issue https://github.com/OurTimeForTech/shiftwork2/issues/13
-


## QA Instructions, Screenshots, Recordings

- Navigate to http://localhost:3000/shifts as a worker and take a shift. 
- Go to the same url again and check the drop button is there. 
- Try to login as a different worker and check that the drop shift button doesn't appear. 
- Login again as the worker who owns the shift, drop it and check the shifts is open again. 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [ ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
