### PR TITLE
create shift_owner method to prevent other users to edit shifts

### DIFF
--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -1,6 +1,7 @@
 class ShiftsController < ApplicationController
   before_action :logged_in_user
   before_action :set_shift, only: %i[ show edit update destroy take drop ]
+  before_action :shift_owner, only: %i[ edit ]
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   def index
@@ -19,6 +20,10 @@ class ShiftsController < ApplicationController
   end
 
   def edit
+    unless shift_owner
+      flash[:danger] = "You are unauthorized to edit this shift."
+      redirect_to user_path(current_user.id)
+    end
   end
 
   def create
@@ -87,5 +92,11 @@ class ShiftsController < ApplicationController
 
   def shift_params
     params.require(:shift).permit(:shift_open, :shift_role, :shift_description, :shift_start, :shift_end, :shift_pay, :organization_id, :worker_id)
+  end
+
+  def shift_owner
+    if @shift.organization_id == current_org_id
+        @shift_owner = true
+    end
   end
 end

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -1,7 +1,7 @@
 class ShiftsController < ApplicationController
   before_action :logged_in_user
   before_action :set_shift, only: %i[ show edit update destroy take drop ]
-  before_action :shift_owner, only: %i[ edit ]
+  before_action :shift_owner?, only: %i[ edit ]
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   def index
@@ -20,9 +20,9 @@ class ShiftsController < ApplicationController
   end
 
   def edit
-    unless shift_owner
+    unless shift_owner?
       flash[:danger] = "You are unauthorized to edit this shift."
-      redirect_to user_path(current_user.id)
+      redirect_to organization_path(current_org_id)
     end
   end
 
@@ -94,9 +94,7 @@ class ShiftsController < ApplicationController
     params.require(:shift).permit(:shift_open, :shift_role, :shift_description, :shift_start, :shift_end, :shift_pay, :organization_id, :worker_id)
   end
 
-  def shift_owner
-    if @shift.organization_id == current_org_id
-        @shift_owner = true
-    end
+  def shift_owner?
+    @shift.organization_id == current_org_id
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [x] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
At the moment any user logged as an organization can edit any shift available if navigates to it through the url.
This PR creates a shift_owner method to prevent any user who is not the shift owner to access to the edit shift view.


## Related PRs and/or Issues (if any)
- https://github.com/OurTimeForTech/shiftwork2/issues/13 step 7
-


## QA Instructions, Screenshots, Recordings



## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [x] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
