### PR TITLE
prevent workers to access the new shift page

### DIFF
--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -15,7 +15,12 @@ class ShiftsController < ApplicationController
   end
 
   def new
-    @shift = Shift.new
+    if current_user.has_org?
+      @shift = Shift.new
+    else
+      flash[:danger] = "You are unauthorized to create new shifts."
+      redirect_to shifts_path
+    end
   end
 
   def edit


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [x] Bug Fix
- [] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does

At the moment a user logged as a worker can access the http://localhost:3000/shifts/new page. This PR only allows user logged in as organizations to see that page

## Related PRs and/or Issues (if any)
- This closes https://github.com/OurTimeForTech/shiftwork2/issues/13 step 7
-


## QA Instructions, Screenshots, Recordings



## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [x] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
