### PR TITLE
Prevent logged in users from accessing sign up page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
 
   def new
     if logged_in?
-        flash[:danger] = "You are unauthorized to create new users."
+        flash[:danger] = "Already logged in. Sign out first to create a new account."
         return redirect_to root_url
     else
         @user = User.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,12 @@ class UsersController < ApplicationController
   end
 
   def new
-    @user = User.new
+    if logged_in?
+        flash[:danger] = "You are unauthorized to create new users."
+        return redirect_to root_url
+    else
+        @user = User.new
+    end
   end
 
   def edit


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [x] Bug Fix
- [] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
Users who are logged in can no longer access the sign up page at '/users/new'. 
If logged in users try to access the page, they will be redirected to the root path with an error message


## Related PRs and/or Issues (if any)
- Fixes #30 
-


## QA Instructions, Screenshots, Recordings
Pulled into local and navigate to http://127.0.0.1:3000/


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [x ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x ] No documentation needed
