### PR TITLE
Sara refactoring permissions in shifts

### DIFF
--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -1,6 +1,7 @@
 class ShiftsController < ApplicationController
   before_action :logged_in_user
   before_action :set_shift, only: %i[ show edit update destroy take drop ]
+  before_action :verify_access, only: %i[ edit update destroy ]
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   def index
@@ -86,8 +87,15 @@ class ShiftsController < ApplicationController
   end
 
   def current_org_id
-    puts "\n\n\nCurrent User ID: #{current_user.id}\n\n\n"
     return Organization.where(user_id: current_user.id).pluck(:id).first
+  end
+
+  # only the organization logged in has access to the shift edit/update/destroy actions
+  def verify_access
+    unless @shift.organization_id == current_org_id
+      flash[:alert] = "You do not have authority to access that."
+      redirect_to user_path(current_user.id)
+    end
   end
 
   def shift_params

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -1,7 +1,6 @@
 class ShiftsController < ApplicationController
   before_action :logged_in_user
   before_action :set_shift, only: %i[ show edit update destroy take drop ]
-  before_action :shift_owner?, only: %i[ edit ]
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   def index
@@ -25,10 +24,6 @@ class ShiftsController < ApplicationController
   end
 
   def edit
-    unless shift_owner?
-      flash[:danger] = "You are unauthorized to edit this shift."
-      redirect_to organization_path(current_org_id)
-    end
   end
 
   def create
@@ -97,9 +92,5 @@ class ShiftsController < ApplicationController
 
   def shift_params
     params.require(:shift).permit(:shift_open, :shift_role, :shift_description, :shift_start, :shift_end, :shift_pay, :organization_id, :worker_id)
-  end
-
-  def shift_owner?
-    @shift.organization_id == current_org_id
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [x] Refactor
- [] Bug Fix
- [x] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
Removes shift_owner method and adds verify_access to ensure that only the organization that is logged in can edit/update/destroy the shift


## Related PRs and/or Issues (if any)
- It closes issue https://github.com/OurTimeForTech/shiftwork2/issues/56
-


## QA Instructions, Screenshots, Recordings

Try to edit a shift (http://localhost:3000/shifts/:id/edit) as an organization and as a worker. Change the shift :id and test access is forbidden if the organization logged in doesn't own it.


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [x] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
