### PR TITLE
Put workers permissions in place

### DIFF
--- a/app/controllers/workers_controller.rb
+++ b/app/controllers/workers_controller.rb
@@ -1,6 +1,7 @@
 class WorkersController < ApplicationController
   before_action :logged_in_user, only: %i[index show new create edit update]
   before_action :set_worker, only: %i[show edit update]
+  before_action :verify_access, only: %i[show edit update]
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
   
   def index
@@ -43,6 +44,14 @@ class WorkersController < ApplicationController
   def set_worker
     @worker = Worker.find(params[:id])
     raise ActiveRecord::RecordNotFound unless @worker
+  end
+
+  # only the worker logged in has access to the worker actions
+  def verify_access
+    unless current_user.id == @worker.user_id
+      flash[:alert] = "You do not have authority to access that."
+      redirect_to user_path(current_user.id)
+    end
   end
 
   def worker_params


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [x] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does

Adds verify_access to workers controller so a user logged in as a organization or a worker different than the account owner can't access show/edit/update


## Related PRs and/or Issues (if any)
- This closes step 3 and 4 from https://github.com/OurTimeForTech/shiftwork2/issues/14 and issue https://github.com/OurTimeForTech/shiftwork2/issues/47
-


## QA Instructions, Screenshots, Recordings

Try to show or edit a worker profile through the url as an organization or a different worker.
http://localhost:3000/workers/:id
http://localhost:3000/workers/:id/edit


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [x] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
