### PR TITLE
Add bio column to org table

### DIFF
--- a/db/migrate/20210428201833_add_bio_to_organizations.rb
+++ b/db/migrate/20210428201833_add_bio_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddBioToOrganizations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :organizations, :bio, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_04_170001) do
+ActiveRecord::Schema.define(version: 2021_04_28_201833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2021_04_04_170001) do
     t.integer "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "bio"
   end
 
   create_table "shifts", force: :cascade do |t|


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [x] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
This PR contains a database migration that adds the bio column to orgs table. 
Bio is an optional column that defaults to null so dev databases should not break.


## Related PRs and/or Issues (if any)
- Completes step 1 of #53 


## QA Instructions, Screenshots, Recordings
Run `rails db:migrate`
 
<img width="1243" alt="Screen Shot 2021-04-28 at 1 28 44 PM" src="https://user-images.githubusercontent.com/29789422/116468519-ce1a0480-a825-11eb-9432-f908e182dce8.png">


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [x] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
