### PR TITLE
Add bio to workers table 

### DIFF
--- a/db/migrate/20210428203135_add_bio_to_workers.rb
+++ b/db/migrate/20210428203135_add_bio_to_workers.rb
@@ -1,0 +1,5 @@
+class AddBioToWorkers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :workers, :bio, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_04_170001) do
+ActiveRecord::Schema.define(version: 2021_04_28_203135) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2021_04_04_170001) do
     t.integer "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "bio"
   end
 
   create_table "shifts", force: :cascade do |t|
@@ -55,6 +56,7 @@ ActiveRecord::Schema.define(version: 2021_04_04_170001) do
     t.integer "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "bio"
   end
 
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [x] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
This PR contains a database migration that adds the bio column to workers table. Bio is an optional column that defaults to null so dev databases should not break.

Please note: the forms will be updated in another PR


## Related PRs and/or Issues (if any)
- Closes step 1 of #52 


## QA Instructions, Screenshots, Recordings
run `rails db:migrate`


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [x ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [ x] No documentation needed
