### PR TITLE
Set conditional org view

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -9,7 +9,11 @@ class OrganizationsController < ApplicationController
   end
 
   def show
-    @org_shifts = Shift.where(organization_id: @organization.id).order("updated_at DESC")
+    if current_user.id == @organization.user_id
+      @org_shifts = Shift.where(organization_id: @organization.id).order("updated_at DESC")
+    else 
+      @organization_bio = Organization.where(id: params[:id]).select(:org_name, :org_address, :org_description, :org_city, :org_state).first
+    end
   end
 
   def new

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,7 +1,7 @@
 class OrganizationsController < ApplicationController
   before_action :logged_in_user, only: %i[show new create edit update]
   before_action :set_organization, only: %i[show edit update]
-  before_action :verify_access, only: %i[show edit update]
+  before_action :verify_access, only: %i[ edit update]
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
   
   

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,4 +1,5 @@
 <div class="container-fluid p-5">
+<% if @org_shifts %>
   <h3>Your Shifts</h3>
 
    <p><%= link_to "Create Shift", new_shift_path, class: "btn btn-primary" %></p>
@@ -32,12 +33,38 @@
                         <div class="col-5 font-weight-bold">Shift Worker</div>
                         <div class="col-7"><% unless shift.shift_open %>Worker Name<% end %></div>
                     </div>
-                    <div class="text-right">
+                    <d class="text-right">
                         <%= link_to "Edit", edit_shift_path(shift.id), class: "btn" %>
                         <%= link_to "Delete", shift_path(shift.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn" %>
-                    </div>                  
+                    </d>                  
                 </div>
             </div>
         <% end %>
     </div> 
+<% else %>
+
+  <div class="card m-auto">
+    <h3 class="card-header"><%= @organization_bio.org_name %></h3>
+    <div class="card-block">
+        <div class="row">
+            <div class="col-4">
+            <ul class="list-group list-group-flush">
+            <li class="list-group-item border-white"><b>Address </b></li>
+            <li class="list-group-item border-white"><b>City </b></li>
+            <li class="list-group-item border-white"><b>State </b></li>
+            <li class="list-group-item border-white"><b>Description </b></li>
+            </ul>   
+            </div>
+            <div class="col-8">
+            <ul class="list-group list-group-flush">
+            <li class="list-group-item"><%= @organization_bio.org_address %></li>
+            <li class="list-group-item"><%= @organization_bio.org_city %></li>
+            <li class="list-group-item"><%= @organization_bio.org_state %></li>
+            <li class="list-group-item"><%= @organization_bio.org_description %></li>
+            </ul>
+            </div>
+        </div>
+    </div>
+  </div>
+<% end %>
 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [] Refactor
- [] Bug Fix
- [] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
Add conditional to the org#show page. If user owns the org, user will see org's shifts. If user does not own the org, will see basic information about the org.
Have styled this to be similar to the user#show view. Am open to formatting changes.


## Related PRs and/or Issues (if any)
- Closes step 2 of #53 


## QA Instructions, Screenshots, Recordings
Try to view 'http://127.0.0.1:3000/organizations/:id'

Note: In these screenshots, I am logged into org 2
<img width="1049" alt="Screen Shot 2021-04-28 at 4 11 31 PM" src="https://user-images.githubusercontent.com/29789422/116484090-34f6e800-a83d-11eb-8585-caa9f4164716.png">
<img width="1022" alt="Screen Shot 2021-04-28 at 4 10 44 PM" src="https://user-images.githubusercontent.com/29789422/116484094-358f7e80-a83d-11eb-8883-3b82441085eb.png">



## Added tests?

- [ ] yes
- [x ] no, because they aren't needed for views
- [ ] no, because I need help
- [ ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x ] No documentation needed
