### PR TITLE
Link to 'org#show' from 'shifts#show'

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -9,7 +9,11 @@ class OrganizationsController < ApplicationController
   end
 
   def show
-    @org_shifts = Shift.where(organization_id: @organization.id).order("updated_at DESC")
+    if current_user.id == @organization.user_id
+      @org_shifts = Shift.where(organization_id: @organization.id).order("updated_at DESC")
+    else 
+      @organization_bio = Organization.where(id: params[:id]).select(:org_name, :org_address, :org_description, :org_city, :org_state).first
+    end
   end
 
   def new

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,7 +1,7 @@
 class OrganizationsController < ApplicationController
   before_action :logged_in_user, only: %i[show new create edit update]
   before_action :set_organization, only: %i[show edit update]
-  before_action :verify_access, only: %i[show edit update]
+  before_action :verify_access, only: %i[ edit update]
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
   
   

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -33,10 +33,10 @@
                         <div class="col-5 font-weight-bold">Shift Worker</div>
                         <div class="col-7"><% unless shift.shift_open %>Worker Name<% end %></div>
                     </div>
-                    <d class="text-right">
+                    <div class="text-right">
                         <%= link_to "Edit", edit_shift_path(shift.id), class: "btn" %>
                         <%= link_to "Delete", shift_path(shift.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn" %>
-                    </d>                  
+                    </div>                  
                 </div>
             </div>
         <% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,4 +1,5 @@
 <div class="container-fluid p-5">
+<% if @org_shifts %>
   <h3>Your Shifts</h3>
 
    <p><%= link_to "Create Shift", new_shift_path, class: "btn btn-primary" %></p>
@@ -32,12 +33,38 @@
                         <div class="col-5 font-weight-bold">Shift Worker</div>
                         <div class="col-7"><% unless shift.shift_open %>Worker Name<% end %></div>
                     </div>
-                    <div class="text-right">
+                    <d class="text-right">
                         <%= link_to "Edit", edit_shift_path(shift.id), class: "btn" %>
                         <%= link_to "Delete", shift_path(shift.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn" %>
-                    </div>                  
+                    </d>                  
                 </div>
             </div>
         <% end %>
     </div> 
+<% else %>
+
+  <div class="card m-auto">
+    <h3 class="card-header"><%= @organization_bio.org_name %></h3>
+    <div class="card-block">
+        <div class="row">
+            <div class="col-4">
+            <ul class="list-group list-group-flush">
+            <li class="list-group-item border-white"><b>Address </b></li>
+            <li class="list-group-item border-white"><b>City </b></li>
+            <li class="list-group-item border-white"><b>State </b></li>
+            <li class="list-group-item border-white"><b>Description </b></li>
+            </ul>   
+            </div>
+            <div class="col-8">
+            <ul class="list-group list-group-flush">
+            <li class="list-group-item"><%= @organization_bio.org_address %></li>
+            <li class="list-group-item"><%= @organization_bio.org_city %></li>
+            <li class="list-group-item"><%= @organization_bio.org_state %></li>
+            <li class="list-group-item"><%= @organization_bio.org_description %></li>
+            </ul>
+            </div>
+        </div>
+    </div>
+  </div>
+<% end %>
 </div>

--- a/app/views/shifts/index.html.erb
+++ b/app/views/shifts/index.html.erb
@@ -1,7 +1,7 @@
 <section class="shifts-list m-4">
 <h2>List of Shifts</h2>
 <% if current_user.has_org? %>
-  <p><%= link_to 'Create Shift', new_shift_path, class: "btn btn-primary" %></p>
+  <p><%= link_to "Create Shift", new_shift_path, class: "btn btn-primary" %></p>
 <% end %>
 
 
@@ -12,7 +12,7 @@
       <h3 class="text-info mb-4"><%= shift.shift_role %></h3>
       <div class="row mb-3">
         <div class="col-4 font-weight-bold">Organization Name</div>
-        <div class="col-8"><%= shift.shift_org_name %></div>
+        <div class="col-8"><%= link_to shift.shift_org_name, organization_path(shift.organization_id) %></div>
       </div>
       <div class="row mb-3">
         <div class="col-4 font-weight-bold">Shift Starts</div>
@@ -36,18 +36,18 @@
       </div>
       <% if current_user.has_org? %>
         <div class="text-right">
-          <span class="m-1"><%= link_to 'Edit', edit_shift_path(shift.id), class: "btn btn-primary" %></span>
-          <span class="m-1"><%= link_to 'Delete', shift_path(shift.id), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-primary" %></span>
+          <span class="m-1"><%= link_to "Edit", edit_shift_path(shift.id), class: "btn btn-primary" %></span>
+          <span class="m-1"><%= link_to "Delete", shift_path(shift.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-primary" %></span>
         </div>
       <% end %>
       <% if current_user.worker? && shift.shift_open %>
         <div class="text-right">
-          <%= link_to 'Take Shift', take_shift_path(shift), method: :put, data: { confirm: 'You will be assigned to work this shift. Proceed?' }, class: "btn btn-primary" %>
+          <%= link_to "Take Shift", take_shift_path(shift), method: :put, data: { confirm: "You will be assigned to work this shift. Proceed?" }, class: "btn btn-primary" %>
         </div>
       <% end %>
       <% if !shift.shift_open && shift.worker_id == current_user.id %>
         <div class="text-right">
-          <%= link_to 'Drop Shift', drop_shift_path(shift), method: :put, data: { confirm: 'You are about to DROP this shift. Proceed?' }, class: "btn btn-danger" %>
+          <%= link_to "Drop Shift", drop_shift_path(shift), method: :put, data: { confirm: "You are about to DROP this shift. Proceed?" }, class: "btn btn-danger" %>
         </div>
       <% end %>
       </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [x] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
This adds a link to the 'organization#show' page from each shift on the 'shifts#show' page


## Related PRs and/or Issues (if any)
- Fixes step 4 of #53
- Built on top of #67 to let users access the org#show 


## QA Instructions, Screenshots, Recordings
Navigate to http://127.0.0.1:3000/shifts
Each shift should now have a link to the org path. 
From PR #67, when users click on the link to view another's org the user will see basic info.

## Added tests?

- [ ] yes
- [ x] no, because they aren't needed for views
- [ ] no, because I need help
- [ ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x ] No documentation needed
