### PR TITLE
Hide shift 'edit' and 'delete' options if shift taken

### DIFF
--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -25,6 +25,10 @@ class ShiftsController < ApplicationController
   end
 
   def edit
+    unless @shift_open
+        flash[:danger] = "This Shift is taken; cannot edit it!"
+        redirect_to shifts_path
+    end
   end
 
   def create

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -25,8 +25,8 @@ class ShiftsController < ApplicationController
   end
 
   def edit
-    unless @shift_open
-        flash[:danger] = "This Shift is taken; cannot edit it!"
+    unless @shift.shift_open?
+        flash[:danger] = "This shift is taken; cannot edit it!"
         redirect_to shifts_path
     end
   end

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -2,6 +2,7 @@ class ShiftsController < ApplicationController
   before_action :logged_in_user
   before_action :set_shift, only: %i[ show edit update destroy take drop ]
   before_action :verify_access, only: %i[ edit update destroy ]
+  before_action :verify_shift_open, only: %i[ edit update destroy ]
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   def index
@@ -25,10 +26,6 @@ class ShiftsController < ApplicationController
   end
 
   def edit
-    unless @shift.shift_open?
-        flash[:danger] = "This shift is taken; cannot edit it!"
-        redirect_to shifts_path
-    end
   end
 
   def create
@@ -99,6 +96,13 @@ class ShiftsController < ApplicationController
     unless @shift.organization_id == current_org_id
       flash[:warning] = "You do not have authority to access that."
       redirect_to user_path(current_user.id)
+    end
+  end
+
+  def verify_shift_open
+    unless @shift.shift_open?
+        flash[:warning] = "This shift is taken; cannot edit it!"
+        redirect_to shifts_path
     end
   end
 

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -33,10 +33,12 @@
                         <div class="col-5 font-weight-bold">Shift Worker</div>
                         <div class="col-7"><% unless shift.shift_open %>Worker Name<% end %></div>
                     </div>
+                    <% if shift.shift_open %>
                     <div class="text-right">
-                        <% if shift.shift_open %><%= link_to "Edit", edit_shift_path(shift.id), class: "btn" %> <% end %>
+                        <%= link_to "Edit", edit_shift_path(shift.id), class: "btn" %>
                         <%= link_to "Delete", shift_path(shift.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn" %>
-                    </div>                  
+                    </div>     
+                     <% end %>             
                 </div>
             </div>
         <% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -33,7 +33,7 @@
                         <div class="col-7"><% unless shift.shift_open %>Worker Name<% end %></div>
                     </div>
                     <div class="text-right">
-                        <%= link_to "Edit", edit_shift_path(shift.id), class: "btn" %>
+                        <% if shift.shift_open %><%= link_to "Edit", edit_shift_path(shift.id), class: "btn" %> <% end %>
                         <%= link_to "Delete", shift_path(shift.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn" %>
                     </div>                  
                 </div>

--- a/app/views/shifts/index.html.erb
+++ b/app/views/shifts/index.html.erb
@@ -1,7 +1,7 @@
 <section class="shifts-list m-4">
 <h2>List of Shifts</h2>
 <% if current_user.has_org? %>
-  <p><%= link_to 'Create Shift', new_shift_path, class: "btn btn-primary" %></p>
+  <p><%= link_to "Create Shift", new_shift_path, class: "btn btn-primary" %></p>
 <% end %>
 
 
@@ -36,18 +36,18 @@
       </div>
       <% if current_user.has_org? %>
         <div class="text-right">
-          <span class="m-1"><%= link_to 'Edit', edit_shift_path(shift.id), class: "btn btn-primary" %></span>
-          <span class="m-1"><%= link_to 'Delete', shift_path(shift.id), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-primary" %></span>
+          <% if shift.shift_open %><span class="m-1"><%= link_to "Edit", edit_shift_path(shift.id), class: "btn btn-primary" %></span><% end %>
+          <span class="m-1"><%= link_to "Delete", shift_path(shift.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-primary" %></span>
         </div>
       <% end %>
       <% if current_user.worker? && shift.shift_open %>
         <div class="text-right">
-          <%= link_to 'Take Shift', take_shift_path(shift), method: :put, data: { confirm: 'You will be assigned to work this shift. Proceed?' }, class: "btn btn-primary" %>
+          <%= link_to "Take Shift", take_shift_path(shift), method: :put, data: { confirm: "You will be assigned to work this shift. Proceed?" }, class: "btn btn-primary" %>
         </div>
       <% end %>
       <% if !shift.shift_open && shift.worker_id == current_user.id %>
         <div class="text-right">
-          <%= link_to 'Drop Shift', drop_shift_path(shift), method: :put, data: { confirm: 'You are about to DROP this shift. Proceed?' }, class: "btn btn-danger" %>
+          <%= link_to "Drop Shift", drop_shift_path(shift), method: :put, data: { confirm: "You are about to DROP this shift. Proceed?" }, class: "btn btn-danger" %>
         </div>
       <% end %>
       </div>

--- a/app/views/shifts/index.html.erb
+++ b/app/views/shifts/index.html.erb
@@ -34,11 +34,11 @@
         <div class="col-4 font-weight-bold">Shift Status</div>
         <div class="col-8<% if shift.shift_open %> text-success">OPEN<% else %> text-danger">Filled<% end %></div>
       </div>
-      <% if current_user.has_org? %>
-        <div class="text-right">
-          <% if shift.shift_open %><span class="m-1"><%= link_to "Edit", edit_shift_path(shift.id), class: "btn btn-primary" %></span><% end %>
-          <span class="m-1"><%= link_to "Delete", shift_path(shift.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-primary" %></span>
-        </div>
+      <% if current_user.has_org? && shift.shift_open? %>
+          <div class="text-right">
+            <span class="m-1"><%= link_to "Edit", edit_shift_path(shift.id), class: "btn btn-primary" %></span>
+            <span class="m-1"><%= link_to "Delete", shift_path(shift.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-primary" %></span>
+          </div>
       <% end %>
       <% if current_user.worker? && shift.shift_open %>
         <div class="text-right">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [x] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
This completes step 2 of #45 . This removes the ability to edit shifts that have been taken. In the org view, orgs cannot see an edit link to the shift. If user tries to edit a shift via url, the shift controller will redirect to shifts page with error message 


## Related PRs and/or Issues (if any)
- Fixes step 2 or #45 
-


## QA Instructions, Screenshots, Recordings

Navigate to 'http://127.0.0.1:3000/organizations/:id' to see how it looks on org page
Or try to directly access an edit page for a filled shift 'http://127.0.0.1:3000/shifts/:id/edit'

<img width="1092" alt="Screen Shot 2021-04-28 at 5 25 03 PM" src="https://user-images.githubusercontent.com/29789422/116488349-0847ce00-a847-11eb-8c8d-5970cd424e8f.png">
<img width="1024" alt="Screen Shot 2021-04-28 at 5 24 48 PM" src="https://user-images.githubusercontent.com/29789422/116488351-08e06480-a847-11eb-964d-3521926d5c25.png">



## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [ x] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [ x] No documentation needed
