### PR TITLE
change flash alert on verify access to warning to have a yellow bkg 

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -50,7 +50,7 @@ class OrganizationsController < ApplicationController
   # only the organization logged in has access to the organization actions
   def verify_access
     unless current_user.id == @organization.user_id
-      flash[:alert] = "You do not have authority to access that."
+      flash[:warning] = "You do not have authority to access that."
       redirect_to user_path(current_user.id)
     end
   end

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -93,7 +93,7 @@ class ShiftsController < ApplicationController
   # only the organization logged in has access to the shift edit/update/destroy actions
   def verify_access
     unless @shift.organization_id == current_org_id
-      flash[:alert] = "You do not have authority to access that."
+      flash[:warning] = "You do not have authority to access that."
       redirect_to user_path(current_user.id)
     end
   end

--- a/app/controllers/workers_controller.rb
+++ b/app/controllers/workers_controller.rb
@@ -49,7 +49,7 @@ class WorkersController < ApplicationController
   # only the worker logged in has access to the worker actions
   def verify_access
     unless current_user.id == @worker.user_id
-      flash[:alert] = "You do not have authority to access that."
+      flash[:warning] = "You do not have authority to access that."
       redirect_to user_path(current_user.id)
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [] Optimization
- [] Documentation Update
- [x] Other (describe: ) Styling change


## Description of what PR does
It changes the flash alert from the verify access method to a warning so the "You do not have authority to access that." message has the warning bootstrap yellowish bkg.

Changed in the shifts, workers and organizations controllers.


## Related PRs and/or Issues (if any)
- It closes https://github.com/OurTimeForTech/shiftwork2/issues/70
-


## QA Instructions, Screenshots, Recordings
This is the current view:
<img width="666" alt="Screenshot 2021-04-29 at 18 07 16" src="https://user-images.githubusercontent.com/2697750/116582622-d81b3080-a915-11eb-8614-182338104dc0.png">

And this the new updated view:
<img width="670" alt="Screenshot 2021-04-29 at 18 07 36" src="https://user-images.githubusercontent.com/2697750/116582656-dfdad500-a915-11eb-8e1b-5099458ba3b7.png">




## Added tests?

- [ ] yes
- [x] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [ ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
