### PR TITLE
Bug between shift and worker 

### DIFF
--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -70,7 +70,7 @@ class ShiftsController < ApplicationController
   end
 
   def drop
-    if @shift.worker_id != current_user.id
+    if @shift.worker_id != current_user.worker_account.id
       flash[:danger] = "Shift is NOT assigned to you; cannot drop."
     else
       @shift.update_columns(worker_id: nil, shift_open: true)

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -63,7 +63,7 @@ class ShiftsController < ApplicationController
       flash[:danger] = "This Shift is already taken!"
       redirect_to shifts_path
     else
-      @shift.update_columns(worker_id: current_user.id, shift_open: false)
+      @shift.update_columns(worker_id: current_user.worker_account.id, shift_open: false)
       flash[:success] = "Shift has been assigned to you successfully!"
       redirect_to worker_path(current_user.worker_account.id)
     end

--- a/app/controllers/workers_controller.rb
+++ b/app/controllers/workers_controller.rb
@@ -8,7 +8,7 @@ class WorkersController < ApplicationController
   end
 
   def show
-    @worker_shifts = Shift.where(worker_id: current_user.id).order("updated_at DESC")
+    @worker_shifts = Shift.where(worker_id: current_user.worker_account.id).order("updated_at DESC")
   end
 
   def new


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
This PR fixes a bug demo'd in today's team sync. Worker id called when workers take and drop shifts. Worker's pages now look for shifts associated with their worker id (will have to use psql to check)


## Related PRs and/or Issues (if any)
- Closes #73 
- Unblocks #45 #52


## QA Instructions, Screenshots, Recordings
Navigate to http://127.0.0.1:3000/
While logged in as a worker, ensure that worker's shifts show on their page. Sign up for a shift to make sure worker's id is stored in database instead of user id


Note: does not alter shifts that are currently in database

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x ] No documentation needed
