### PR TITLE
styling drop shift button from workers view

### DIFF
--- a/app/views/workers/show.html.erb
+++ b/app/views/workers/show.html.erb
@@ -46,7 +46,7 @@
                     
   <% if current_user.worker? && Time.current < shift.shift_start %>
      <div class="text-right">
-      <%= link_to 'Drop Shift', drop_shift_path(shift), method: :put, data: { confirm: 'You are about to DROP this shift. Proceed?', class: "btn btn-primary" } %>
+      <%= link_to 'Drop Shift', drop_shift_path(shift), method: :put, data: { confirm: 'You are about to DROP this shift. Proceed?' }, class: "btn btn-danger" %>
    </div>
   <% end %>
   </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [x] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
It adds the same styling as the shifts page to the drop shift button in the "view assigned shifts" workers view

<img width="777" alt="Screenshot 2021-04-30 at 18 32 30" src="https://user-images.githubusercontent.com/2697750/116725666-868ca780-a9e2-11eb-8c96-09bd7eca2406.png">

Shifts view:
<img width="776" alt="Screenshot 2021-04-30 at 18 32 44" src="https://user-images.githubusercontent.com/2697750/116725670-88ef0180-a9e2-11eb-8f74-4821926dcbd3.png">




## Related PRs and/or Issues (if any)
- Step 6 https://github.com/OurTimeForTech/shiftwork2/issues/10
-


## QA Instructions, Screenshots, Recordings
It can be seen at http://localhost:3000/workers/id


## Added tests?

- [ ] yes
- [x] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [ ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [ ] No documentation needed
