### PR TITLE
Display and link worker name in org view

### DIFF
--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -14,6 +14,11 @@ class Shift < ApplicationRecord
     Organization.where(id: self.organization_id).first.org_name
   end
 
+  def shift_worker_name
+    worker = Worker.where(id: self.worker_id).first
+    return "#{worker.first_name} #{worker.last_name}"
+  end
+
   private
 
   def shift_end_after_start  

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -16,7 +16,9 @@ class Shift < ApplicationRecord
 
   def shift_worker_name
     worker = Worker.where(id: self.worker_id).first
-    return "#{worker.first_name} #{worker.last_name}"
+    if worker
+      return "#{worker.first_name} #{worker.last_name}" 
+    end
   end
 
   private

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -31,7 +31,7 @@
                     </div>
                     <div class="row mb-3">
                         <div class="col-5 font-weight-bold">Shift Worker</div>
-                        <div class="col-7"><% unless shift.shift_open %>Worker Name<% end %></div>
+                        <div class="col-7"><% unless shift.shift_open %><%= shift.shift_worker_name %><% end %></div>
                     </div>
                     <% if shift.shift_open %>
                     <div class="text-right">

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -31,7 +31,7 @@
                     </div>
                     <div class="row mb-3">
                         <div class="col-5 font-weight-bold">Shift Worker</div>
-                        <div class="col-7"><% unless shift.shift_open %><%= shift.shift_worker_name %><% end %></div>
+                        <div class="col-7"><% unless shift.shift_open %><%= link_to shift.shift_worker_name, worker_path(shift.worker_id) %><% end %></div>
                     </div>
                     <% if shift.shift_open %>
                     <div class="text-right">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [] Bug Fix
- [x] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
This adds a dynamically coded worker's name on the shifts cards seen in 'org#show' view. Clicking on the name will lead to that worker's bio. 

Note: Worker's name are intentionally not shown in shifts#index view. 


## Related PRs and/or Issues (if any)
- This fixes step 2 from #45 and step 2 from #52
-


## QA Instructions, Screenshots, Recordings
Navigate to 'http://127.0.0.1:3000/organizations/:id' to confirm that filled shifts now display worker name and that clicking on the name leads to the worker's bio


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [x] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [ ] No documentation needed
