### PR TITLE
Add restrictions to /workers/new action

### DIFF
--- a/app/controllers/workers_controller.rb
+++ b/app/controllers/workers_controller.rb
@@ -14,10 +14,10 @@ class WorkersController < ApplicationController
   end
 
   def new
-    @existing_worker = Worker.where(user_id: current_user.id)
-    @existing_org = Organization.where(user_id: current_user.id)
+    @existing_worker = Worker.where(user_id: current_user.id).first
+    @is_user_worker = User.where(id: current_user.id, user_type: 'worker').first
 
-    if @existing_worker.blank? && @existing_org.blank?
+    if @is_user_worker && @existing_worker.blank?
       @worker = Worker.new
     else
       flash[:danger] = "You are unauthorized to create a new worker."

--- a/app/controllers/workers_controller.rb
+++ b/app/controllers/workers_controller.rb
@@ -14,7 +14,15 @@ class WorkersController < ApplicationController
   end
 
   def new
-    @worker = Worker.new
+    @existing_worker = Worker.where(user_id: current_user.id)
+    @existing_org = Organization.where(user_id: current_user.id)
+
+    if @existing_worker.blank? && @existing_org.blank?
+      @worker = Worker.new
+    else
+      flash[:danger] = "You are unauthorized to create a new worker."
+      redirect_to shifts_path
+    end
   end
 
   def edit


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Refactor
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Other (describe: )


## Description of what PR does
The workers/new action now checks that the user has a worker user type and does not have an existing worker account before displaying the Create New Worker form.


## Related PRs and/or Issues (if any)
- Closes #92 
- Addresses 2 failing tests in #88 

## QA Instructions, Screenshots, Recordings
Navigate to 'http://127.0.0.1:3000/workers/new'
Worker users that do not have an associated worker account should see the Create New Worker form
Org users and workers with existing worker account should be redirected with error message


## Added tests?

- [ ] yes
- [x] no, because they aren't needed because they are already added
- [ ] no, because I need help
- [ ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
