### PR TITLE
Adding restrictions to create new organization page

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -17,7 +17,19 @@ class OrganizationsController < ApplicationController
   end
 
   def new
-    @organization = Organization.new
+    # check if the user is an organization before showing the create organization form.
+    if current_user.user_type == 'organization' 
+      # if it is an organization, check if the organization profile has been already created
+      if current_user.has_org?
+        flash[:warning] = "You have already created your organization."
+        redirect_to user_path(current_user.id)
+      else
+        @organization = Organization.new
+      end
+    else
+      flash[:danger] = "You do not have authority to access that."
+      redirect_to user_path(current_user.id)
+    end
   end
 
   def create


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [x] Bug Fix
- [] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
It redirects users logged in as organizations to their main user page (http://localhost:3000/users/id) when they try to access "organizations/new" if they have already created the org and add the "You have already created your organization." alert.

It redirect users logged in as workers to their main user page (http://localhost:3000/users/id) when they try to access "organizations/new" and add the "You do not have authority to access that." alert.


## Related PRs and/or Issues (if any)
- https://github.com/OurTimeForTech/shiftwork2/issues/90
-


## QA Instructions, Screenshots, Recordings
Navigate to http://localhost:3000/organizations/new as a worker or as a organization already created. It should redirect you to the user page.
Sign up as an organization user and try to create your organization. It should work as usual.


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [x] no, they are added here https://github.com/OurTimeForTech/shiftwork2/pull/91


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
