### PR TITLE
Update behaviour for shifts with a start date in the past

### DIFF
--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -9,7 +9,7 @@ class ShiftsController < ApplicationController
     if current_user.has_org?
       redirect_to organization_path(current_org_id)
     else
-      @shifts = Shift.all.order("updated_at DESC")
+      @shifts = Shift.where("shift_start > ?", Time.now.utc).order("updated_at DESC")
     end
   end
 

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -7,7 +7,8 @@
     <div class="row container-fluid mr-0">
         <% @org_shifts.each do |shift| %>
             <div class="shift col-12 col-lg-6 col-xl-4 my-2 pl-0">
-                <div class="border bg-light p-4">
+                <div class="border bg-light <% if shift.shift_start < Time.now.utc %>border-danger<% end %> p-4">
+                <% if shift.shift_start < Time.now.utc %><h4 class="text-danger">OUTDATED shift!!</h4> <% end %>
                     <h3 class="text-info mb-4"><%= shift.shift_role %></h3>
                     <div class="row mb-3">
                         <div class="col-5 font-weight-bold">Shift Starts</div>
@@ -41,7 +42,7 @@
                     <% end %>
                     <div class="text-right">
                         <% if shift.shift_open %>
-                            <%= link_to "Edit", edit_shift_path(shift.id), class: "btn btn-primary" %>
+                            <% if shift.shift_start > Time.now.utc %><%= link_to "Edit", edit_shift_path(shift.id), class: "btn btn-primary" %><% end %>
                             <%= link_to "Delete", shift_path(shift.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger" %>
                         <% else %>
                             <p class="mt-4 text-muted">Your shift has been filled and cannot be edited or deleted</p>

--- a/app/views/workers/show.html.erb
+++ b/app/views/workers/show.html.erb
@@ -5,7 +5,12 @@
     <div class="row container-fluid mr-0">
       <% @worker_shifts.each do |shift| %>
         <div class="shift col-12 col-lg-6 col-xl-4 my-2 pl-0">
-          <div class="border bg-light p-4">        
+          <div class="border bg-light p-4 <% if shift.shift_start < Time.now.utc %>border-danger<% end %> "> 
+            <% if shift.shift_start < Time.now.utc %>  
+              <div class="row mb-3">
+                <div class="col-12 font-weight-bold text-danger">CURRENT/FINISHED SHIFT</div> 
+              </div>
+            <% end %>     
             <div class="row mb-3">
               <div class="col-5 font-weight-bold">Organization Name</div> 
               <div class="col-7"><%= shift.shift_org_name %></div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [x] Bug Fix
- [] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
This PR prevents shifts with a start date in the past to show up in the main shifts view.

It also modifies slightly the main organizations and workers view (/organizations/id and workers/id) so shifts with a start date in the past are flagged.


## Related PRs and/or Issues (if any)
-https://github.com/OurTimeForTech/shiftwork2/issues/96
-


## QA Instructions, Screenshots, Recordings
Working on this another bug came up https://github.com/OurTimeForTech/shiftwork2/issues/97
So while that is not fixed, you can create a shift in the past as an organization and then login as a worker. That shift should not appear on the worker full list of shifts.

Also, in the http://localhost:3000/organizations/id view, that shift should look like this:
<img width="1060" alt="Screenshot 2021-05-18 at 18 06 02" src="https://user-images.githubusercontent.com/2697750/118690213-1ebec500-b808-11eb-9aa1-0047583450d3.png">


And the http://localhost:3000/workers/id
<img width="1006" alt="Screenshot 2021-05-18 at 18 14 28" src="https://user-images.githubusercontent.com/2697750/118690266-2f6f3b00-b808-11eb-8849-e7096817b87a.png">




## Added tests?

- [ ] yes
- [x] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [ ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
