### PR TITLE
org cannot create shifts in the past and shift has to start at least one hour before current time

### DIFF
--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -33,11 +33,11 @@ class Shift < ApplicationRecord
 
   private
   def any_shift_time_blank?
-    return if self.shift_start.blank? || self.shift_end.blank?
+    self.shift_start.blank? || self.shift_end.blank?
   end
 
   def shift_not_too_short
-    any_shift_time_blank?
+    return if any_shift_time_blank?
 
     if ((self.shift_end - self.shift_start) / 1.hour) < 1
       errors.add(:shift, "duration must be at least 1 hour!")
@@ -45,7 +45,7 @@ class Shift < ApplicationRecord
   end
 
   def shift_ends_after_start
-    any_shift_time_blank?
+    return if any_shift_time_blank?
     
     if self.shift_end < self.shift_start
       errors.add(:shift, "cannot end before it starts!")
@@ -53,7 +53,8 @@ class Shift < ApplicationRecord
   end
 
   def shift_start_before_current_date?
-    any_shift_time_blank?
+    return if any_shift_time_blank?
+
     if shift_start < Time.zone.now - 100
       errors.add(:shift_start, "cannot be in the past") 
     elsif shift_start < Time.zone.now + 3600

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -10,6 +10,7 @@ class Shift < ApplicationRecord
   
   validate :shift_not_too_short
   validate :shift_ends_after_start
+  validate :shift_start_before_current_date?
 
   def shift_org_name
     Organization.where(id: self.organization_id).first.org_name
@@ -45,6 +46,14 @@ class Shift < ApplicationRecord
     
     if self.shift_end < self.shift_start
       errors.add(:shift, "cannot end before it starts!")
+    end
+  end
+
+  def shift_start_before_current_date?
+    if shift_start < Time.zone.now - 100
+      errors.add :shift_start, "cannot be in the past" 
+    elsif shift_start < Time.zone.now + 3600
+      errors.add :shift_start, "must be created at least an hour before start" 
     end
   end
 

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -32,9 +32,12 @@ class Shift < ApplicationRecord
   end
 
   private
+  def any_shift_time_blank?
+    return if self.shift_start.blank? || self.shift_end.blank?
+  end
 
   def shift_not_too_short
-    return if self.shift_start.blank? || self.shift_end.blank?
+    any_shift_time_blank?
 
     if ((self.shift_end - self.shift_start) / 1.hour) < 1
       errors.add(:shift, "duration must be at least 1 hour!")
@@ -42,7 +45,7 @@ class Shift < ApplicationRecord
   end
 
   def shift_ends_after_start
-    return if self.shift_start.blank? || self.shift_end.blank?
+    any_shift_time_blank?
     
     if self.shift_end < self.shift_start
       errors.add(:shift, "cannot end before it starts!")
@@ -50,7 +53,7 @@ class Shift < ApplicationRecord
   end
 
   def shift_start_before_current_date?
-    return if self.shift_start.blank? || self.shift_end.blank?
+    any_shift_time_blank?
     if shift_start < Time.zone.now - 100
       errors.add(:shift_start, "cannot be in the past") 
     elsif shift_start < Time.zone.now + 3600

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -50,10 +50,11 @@ class Shift < ApplicationRecord
   end
 
   def shift_start_before_current_date?
+    return if self.shift_start.blank? || self.shift_end.blank?
     if shift_start < Time.zone.now - 100
-      errors.add :shift_start, "cannot be in the past" 
+      errors.add(:shift_start, "cannot be in the past") 
     elsif shift_start < Time.zone.now + 3600
-      errors.add :shift_start, "must be created at least an hour before start" 
+      errors.add(:shift_start, "must be created at least an hour before start") 
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] Feature
- [] Refactor
- [x] Bug Fix
- [] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
closes issue #97 


## Related PRs and/or Issues (if any)
- #97 
-


## QA Instructions, Screenshots, Recordings

- log in as an org user
- create a shift that starts in the past (you should get an error)
- create a shift that starts less than an hour from the Current time in your Time zone (you should get an error)


## Added tests?

- [ ] yes
- [x] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [ ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
