### PR TITLE
modified should redirect to worker_path and display success message if shift dropped successfully Test

### DIFF
--- a/spec/requests/shifts_controller_spec.rb
+++ b/spec/requests/shifts_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "ShiftsControllers", type: :request do
   let(:sample_worker_1) { create(:worker) }
   let(:sample_worker_2) { create(:worker) }
   let(:sample_shift_1) { create(:shift, :chef_role, :filled_shift, worker_id: sample_worker_1.id) }
+  let(:sample_shift_2) { create(:shift, :chef_role, :filled_shift, worker_id: sample_worker_1.id, shift_start: DateTime.now + 1.day + 2.hours, shift_end: DateTime.now + 1.day + 5.hours) }
   let(:shift_starting_soon) { create(:shift, :chef_role, :filled_shift, worker_id: sample_worker_2.id, shift_start: DateTime.now + 6.hours, shift_end: DateTime.now + 18.hours) }
 
   describe "GET /index action" do
@@ -211,7 +212,7 @@ RSpec.describe "ShiftsControllers", type: :request do
       worker_user = User.find_by(id: sample_worker_1.user_id)
       login_as(worker_user.email, "password123")
 
-      patch drop_shift_path(sample_shift_1.id)
+      patch drop_shift_path(sample_shift_2.id)
 
       expect(response).to have_http_status(302)
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [] Feature
- [x] Refactor
- [] Bug Fix
- [] Optimization
- [] Documentation Update
- [] Other (describe: )


## Description of what PR does
closes #101 
Added the sample shift that starts more than 24 hours from the current time, so it can be successfully dropped.
The test was failing due to some recent changes to the Shift Model.😊

## Related PRs and/or Issues (if any)
-
-


## QA Instructions, Screenshots, Recordings
run ```bundle exec rspec spec/requests/shifts_controller_spec.rb```


## Added tests?

- [x] yes
- [ ] no, because they aren't needed _(please include reasons for why tests aren't needed)_
- [ ] no, because I need help
- [ ] no, they will be added later (please create an Issue for it)


## Added to documentation?

- [ ] Yes, project README
- [x] No documentation needed
